### PR TITLE
Upgrade to .NET 10 and increment the package to version to 2.0.0. Pre…

### DIFF
--- a/.github/workflows/dotnet-nuget.yml
+++ b/.github/workflows/dotnet-nuget.yml
@@ -43,6 +43,10 @@ jobs:
 
     - name: Pack NuGet Package
       run: dotnet pack Timezoner --no-build --configuration Release --output nupkg
+    
+    - name: Get timestamp
+      id: timestamp
+      run: echo "timestamp=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
 
     # Only publish on master branch commits (not PRs)
     - name: Push to NuGet.org
@@ -54,8 +58,8 @@ jobs:
       if: github.event_name != 'pull_request'
       uses: softprops/action-gh-release@v1
       with:
-        tag_name: v${{ github.run_number }}
-        name: Release v${{ github.run_number }}
+        tag_name: release-${{ steps.timestamp.outputs.timestamp }}
+        name: Release ${{ steps.timestamp.outputs.timestamp }}
         files: nupkg/*.nupkg
         generate_release_notes: true
       env:


### PR DESCRIPTION
Upgrade to .NET 10 and increment the package to version to 2.0.0. Previous version of .NET will continue to use previous package versions that are available on NuGet. Update CI/CD to create GitHub Releases.